### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   build-web:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/ivanm696/solid-giggle/security/code-scanning/11](https://github.com/ivanm696/solid-giggle/security/code-scanning/11)

Add an explicit top-level `permissions` block in `.github/workflows/ci.yml` so all jobs inherit least-privilege token access unless overridden.  
Best fix here (without changing behavior) is to add:

```yml
permissions:
  contents: read
```

near the top of the workflow (after `on:` block and before `jobs:`). This is sufficient for `actions/checkout` and build/test tasks that only read repository contents. No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a top-level `permissions: contents: read` to `.github/workflows/ci.yml` to enforce least-privilege for all jobs and resolve code scanning alert 11 (workflow missing permissions). No behavior change; this is sufficient for `actions/checkout` and build/test steps.

<sup>Written for commit 58aeed99bbaf9f5665cb5de8a9ffaa0aa107f1ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ivanm696/solid-giggle/pull/163?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

